### PR TITLE
Fix: Prevent duplicate email reminders by disabling Flask reloader

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -20,7 +20,8 @@ def main():
     
     # Use the correct port from Render
     port = int(os.environ.get("PORT", 5000))
-    app.run(debug=Config.DEBUG, host="0.0.0.0", port=port)
+    # Disable reloader to prevent multiple scheduler instances during development
+    app.run(debug=Config.DEBUG, host="0.0.0.0", port=port, use_reloader=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The Flask development server's auto-reloader was causing the application to initialize multiple times, leading to multiple email scheduler instances and duplicate reminder emails.

This commit disables the auto-reloader in the development environment by setting `use_reloader=False` in `app.run()` in `app/main.py`.