### PR TITLE
Include OCM and PPM tasks in email reminders

### DIFF
--- a/data/ocm.json
+++ b/data/ocm.json
@@ -11,7 +11,7 @@
     "Warranty_End": "1/6/2024",
     "Service_Date": "1/9/2025",
     "Engineer": "eng1",
-    "Next_Maintenance": "20/06/2025",
+    "Next_Maintenance": "15/01/2025",
     "Status": "Upcoming"
   },
   {

--- a/data/ppm.json
+++ b/data/ppm.json
@@ -11,7 +11,7 @@
     "Warranty_End": "20/03/2024",
     "PPM_Q_I": {
       "engineer": "Eng1",
-      "quarter_date": "20/06/2025"
+      "quarter_date": "20/01/2025"
     },
     "PPM_Q_II": {
       "engineer": "Eng2",


### PR DESCRIPTION
- Modified data files (ocm.json, ppm.json) to include testable upcoming dates.
- Adapted EmailService.get_upcoming_maintenance to process both OCM and PPM data types, returning a unified data structure.
- Updated EmailService.send_reminder_email to use the new unified task structure and adjusted the HTML email table accordingly.
- Ensured EmailService.process_reminders correctly combines and sorts OCM and PPM tasks before sending emails.
- Refactored EmailService test data and updated tests for get_upcoming_maintenance. Other tests related to email service were refactored by the user.