### PR TITLE
feat: Implement email notification controls in settings

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -22,6 +22,7 @@ class Config:
     DATA_DIR = os.path.join(BASE_DIR, "data")
     PPM_JSON_PATH = os.path.join(DATA_DIR, "ppm.json")
     OCM_JSON_PATH = os.path.join(DATA_DIR, "ocm.json")
+    SETTINGS_JSON_PATH = os.path.join(DATA_DIR, "settings.json")
     
     # Mailjet configuration
     MAILJET_API_KEY = os.getenv("MAILJET_API_KEY", "")

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -243,6 +243,14 @@ class EmailService:
         from app.services.data_service import DataService
 
         try:
+            # Load application settings
+            settings = DataService.load_settings()
+            email_enabled = settings.get("email_notifications_enabled", True) # Default to True if missing
+
+            if not email_enabled:
+                logger.info("Email notifications are disabled in settings. Skipping reminder process.")
+                return
+
             # Load PPM data
             ppm_data = DataService.load_data('ppm')
 

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -1,0 +1,76 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const settingsForm = document.getElementById('settingsForm');
+    const emailNotificationsToggle = document.getElementById('emailNotificationsToggle');
+    const emailIntervalInput = document.getElementById('emailInterval');
+    const alertContainer = document.getElementById('alertContainer'); // Assuming an alert container is added to HTML
+
+    // Function to display alerts
+    function showAlert(message, type = 'success') {
+        if (!alertContainer) return;
+        const alertDiv = `
+            <div class="alert alert-${type} alert-dismissible fade show" role="alert">
+                ${message}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        `;
+        alertContainer.innerHTML = alertDiv;
+    }
+
+    // Load current settings
+    fetch('/api/settings')
+        .then(response => {
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            return response.json();
+        })
+        .then(settings => {
+            emailNotificationsToggle.checked = settings.email_notifications_enabled === true;
+            emailIntervalInput.value = settings.email_reminder_interval_minutes || 60;
+        })
+        .catch(error => {
+            console.error('Error loading settings:', error);
+            showAlert('Failed to load current settings. Please try again later.', 'danger');
+        });
+
+    // Handle form submission
+    if (settingsForm) {
+        settingsForm.addEventListener('submit', function (event) {
+            event.preventDefault();
+            alertContainer.innerHTML = ''; // Clear previous alerts
+
+            const settingsData = {
+                email_notifications_enabled: emailNotificationsToggle.checked,
+                email_reminder_interval_minutes: parseInt(emailIntervalInput.value, 10)
+            };
+
+            // Basic client-side validation
+            if (isNaN(settingsData.email_reminder_interval_minutes) || settingsData.email_reminder_interval_minutes <= 0) {
+                showAlert('Email interval must be a positive number.', 'danger');
+                return;
+            }
+
+            fetch('/api/settings', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(settingsData),
+            })
+            .then(response => response.json().then(data => ({ status: response.status, body: data })))
+            .then(({ status, body }) => {
+                if (status === 200 && body.message) {
+                    showAlert(body.message, 'success');
+                } else if (body.error) {
+                    showAlert(`Error: ${body.error}`, 'danger');
+                } else {
+                    showAlert('An unknown error occurred while saving settings.', 'danger');
+                }
+            })
+            .catch(error => {
+                console.error('Error saving settings:', error);
+                showAlert('Failed to save settings. Check console for details.', 'danger');
+            });
+        });
+    }
+});

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -5,23 +5,27 @@
     <h2>Settings</h2>
     <hr>
 
+    <!-- Alert container -->
+    <div id="alertContainer"></div>
+
     <form id="settingsForm">
         <!-- Email Notifications Toggle -->
         <div class="mb-3 form-check form-switch">
             <input class="form-check-input" type="checkbox" role="switch" id="emailNotificationsToggle" name="email_notifications">
-            <label class="form-check-label" for="emailNotificationsToggle">Enable Email Notifications</label>
+            <label class="form-check-label" for="emailNotificationsToggle">Enable Email Notifications for Reminders</label>
         </div>
 
         <!-- Time Interval for Emails -->
         <div class="mb-3">
-            <label for="emailInterval" class="form-label">Time interval between emails (in minutes)</label>
+            <label for="emailInterval" class="form-label">Reminder Email Check Interval (in minutes)</label>
             <input type="number" class="form-control" id="emailInterval" name="email_interval" placeholder="e.g., 60" min="1">
+            <small class="form-text text-muted">This setting might be used by the system scheduler to determine how often to check for and send reminder emails. The exact behavior depends on the backend scheduler's implementation.</small>
         </div>
 
-        <!-- Desktop Push Notifications Toggle -->
+        <!-- Desktop Push Notifications Toggle (Keep for future use, but not implemented in this task) -->
         <div class="mb-3 form-check form-switch">
-            <input class="form-check-input" type="checkbox" role="switch" id="desktopNotificationsToggle" name="desktop_notifications">
-            <label class="form-check-label" for="desktopNotificationsToggle">Enable Desktop Push Notifications</label>
+            <input class="form-check-input" type="checkbox" role="switch" id="desktopNotificationsToggle" name="desktop_notifications" disabled>
+            <label class="form-check-label" for="desktopNotificationsToggle">Enable Desktop Push Notifications (Feature not active)</label>
         </div>
 
         <hr>
@@ -29,4 +33,9 @@
     </form>
 </div>
 
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/settings.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
Adds functionality to control email reminder notifications via the settings page.

Key changes:
- Settings (email enabled/disabled, reminder interval) are stored in data/settings.json.
- API endpoints (/api/settings GET and POST) created to manage these settings.
- Settings page UI now fetches and saves these preferences using new JavaScript (app/static/js/settings.js).
- EmailService now checks the 'email_notifications_enabled' setting before processing and sending reminder emails.
- Configuration updated to include the path to settings.json.