### PR TITLE
Fix: Correct email notification toggle and interval saving

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -31,6 +31,7 @@ class Config:
     EMAIL_RECEIVER = os.getenv("EMAIL_RECEIVER", "")
 
     # Reminder configuration
-    REMINDER_DAYS = int(os.getenv("REMINDER_DAYS", "60"))
-    SCHEDULER_ENABLED = os.getenv("SCHEDULER_ENABLED", "True").lower() == "true"
-    SCHEDULER_INTERVAL = int(os.getenv("SCHEDULER_INTERVAL", "24"))  # hours
+    REMINDER_DAYS = int(os.getenv("REMINDER_DAYS", "60")) # Days ahead to look for maintenance tasks
+    SCHEDULER_ENABLED = os.getenv("SCHEDULER_ENABLED", "True").lower() == "true" # Global switch for the email scheduler thread
+    # SCHEDULER_INTERVAL (previously here) has been removed as the interval is now managed dynamically
+    # via 'email_reminder_interval_minutes' in settings.json

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -314,10 +314,11 @@ def get_settings():
 def save_settings():
     """Save application settings."""
     if not request.is_json:
+        logger.warning("Save settings request is not JSON.")
         return jsonify({"error": "Request must be JSON"}), 400
 
     data = request.get_json()
-    logger.info(f"Received settings to save: {data}")
+    logger.info(f"Received settings data for saving: {data}")
 
     # Basic validation for expected keys and types
     email_notifications_enabled = data.get("email_notifications_enabled")

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -17,16 +17,20 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     // Load current settings
+    console.log('Attempting to load current settings...');
     fetch('/api/settings')
         .then(response => {
             if (!response.ok) {
+                console.error('Failed to fetch settings, status:', response.status);
                 throw new Error(`HTTP error! status: ${response.status}`);
             }
             return response.json();
         })
         .then(settings => {
+            console.log('Received settings:', settings);
             emailNotificationsToggle.checked = settings.email_notifications_enabled === true;
-            emailIntervalInput.value = settings.email_reminder_interval_minutes || 60;
+            emailIntervalInput.value = settings.email_reminder_interval_minutes || 60; // Default to 60 if undefined
+            console.log('Applied settings to form elements. Toggle checked:', emailNotificationsToggle.checked, 'Interval value:', emailIntervalInput.value);
         })
         .catch(error => {
             console.error('Error loading settings:', error);
@@ -38,17 +42,24 @@ document.addEventListener('DOMContentLoaded', function () {
         settingsForm.addEventListener('submit', function (event) {
             event.preventDefault();
             alertContainer.innerHTML = ''; // Clear previous alerts
+            console.log('Settings form submitted.');
+
+            const intervalValue = parseInt(emailIntervalInput.value, 10);
+            console.log('Raw interval input value:', emailIntervalInput.value, 'Parsed interval value:', intervalValue);
 
             const settingsData = {
                 email_notifications_enabled: emailNotificationsToggle.checked,
-                email_reminder_interval_minutes: parseInt(emailIntervalInput.value, 10)
+                email_reminder_interval_minutes: intervalValue
             };
+            console.log('Data to be sent:', settingsData);
 
             // Basic client-side validation
             if (isNaN(settingsData.email_reminder_interval_minutes) || settingsData.email_reminder_interval_minutes <= 0) {
+                console.warn('Validation failed: Email interval must be a positive number. Value:', settingsData.email_reminder_interval_minutes);
                 showAlert('Email interval must be a positive number.', 'danger');
                 return;
             }
+            console.log('Client-side validation passed.');
 
             fetch('/api/settings', {
                 method: 'POST',


### PR DESCRIPTION
- Modified EmailService to run periodically, respecting the 'email_notifications_enabled' flag and 'email_reminder_interval_minutes' from settings.json for its operational cycle.
- Ensured settings are loaded dynamically by the EmailService in each cycle.
- Added comprehensive logging to EmailService, DataService (settings part), API (settings endpoint), and client-side settings.js to improve traceability and debugging for email scheduling and settings management.
- Removed unused 'SCHEDULER_INTERVAL' from app/config.py as interval is now managed via settings.json.

This resolves issues where the email notification toggle was not effective after startup and the email interval was not being correctly used or saved.