### PR TITLE
Fix: Ensure background email scheduler starts correctly with Gunicorn

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,10 +9,36 @@ import logging
 import os
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
+import threading # Added import
 
 from flask import Flask
 from app.utils.logger_setup import setup_logger
 from app.config import Config
+
+
+# This function remains here as it's called by the thread started in create_app
+def start_email_scheduler():
+    """Start the email scheduler."""
+    # This function is intended to be run in a separate thread
+    from app.services.email_service import EmailService
+
+    logger = logging.getLogger(__name__) # Get a logger instance
+
+    # Create a new event loop for this thread
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    try:
+        logger.info("Background thread for scheduler is starting.")
+        # EmailService.run_scheduler_async_loop will now handle the singleton check
+        loop.run_until_complete(EmailService.run_scheduler_async_loop())
+    except Exception as e:
+        logger.error(f"Exception in the email scheduler thread: {str(e)}", exc_info=True)
+    finally:
+        if loop.is_running():
+            loop.stop() # Stop the loop if it's still running
+        loop.close()
+        logger.info("Background thread for scheduler has finished.")
 
 
 def create_app():
@@ -25,7 +51,9 @@ def create_app():
     app = Flask(__name__)
     
     # Set up logging
-    logger = setup_logger('app')
+    # Ensure logger is available for the scheduler start message
+    logger = setup_logger('app') # Assuming this returns the 'app' logger configured
+    app.logger = logger # Also assign to app.logger if not done by setup_logger implicitly for Flask
     logger.info('Initializing application')
     
     # Load configuration
@@ -40,31 +68,22 @@ def create_app():
     
     app.register_blueprint(views_bp)
     app.register_blueprint(api_bp, url_prefix='/api')
-    
+
+    # Start the scheduler in a background thread if enabled
+    # This will be called when Gunicorn workers are initialized.
+    # The EmailService itself has a lock (_scheduler_running)
+    # to prevent multiple instances of the scheduler loop from running.
+    if Config.SCHEDULER_ENABLED:
+        # Each Gunicorn worker will call create_app(), thus creating this thread.
+        # The EmailService.run_scheduler_async_loop() has an internal lock
+        # (_scheduler_lock and _scheduler_running) to ensure only one
+        # instance of the actual scheduling logic runs across all workers/threads.
+        scheduler_thread = threading.Thread(target=start_email_scheduler, daemon=True)
+        scheduler_thread.start()
+        logger.info("Email scheduler thread initiated from create_app.")
+    else:
+        logger.info("Scheduler is disabled in config (SCHEDULER_ENABLED=False).")
+
     logger.info('Application initialization complete')
     
     return app
-
-
-def start_email_scheduler():
-    """Start the email scheduler."""
-    # This function is intended to be run in a separate thread by app/main.py
-    from app.services.email_service import EmailService
-    
-    logger = logging.getLogger(__name__) # Get a logger instance
-
-    # Create a new event loop for this thread
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    
-    try:
-        logger.info("Background thread for scheduler is starting.")
-        # EmailService.run_scheduler_async_loop will now handle the singleton check
-        loop.run_until_complete(EmailService.run_scheduler_async_loop())
-    except Exception as e:
-        logger.error(f"Exception in the email scheduler thread: {str(e)}", exc_info=True)
-    finally:
-        if loop.is_running():
-            loop.stop() # Stop the loop if it's still running
-        loop.close()
-        logger.info("Background thread for scheduler has finished.")

--- a/app/main.py
+++ b/app/main.py
@@ -1,28 +1,51 @@
 """
 Main entry point for the Hospital Equipment Maintenance Management System.
+(Primarily for local development if not using Gunicorn directly)
 """
 
 import logging
-import threading
 import os
-from app import create_app, start_email_scheduler
+from app import create_app # create_app now handles scheduler initialization
 from app.config import Config
 
 logger = logging.getLogger(__name__)
 
 
 def main():
-    app = create_app()
+    """
+    Main function to run the Flask development server.
+    The scheduler is now started within create_app, so it doesn't need
+    to be explicitly started here.
+    This entry point is mostly for development.
+    For production, Gunicorn calls create_app() directly via run.sh.
+    """
+    app = create_app() # This will also attempt to start the scheduler
+    
+    # Use the correct port from Render or a local default
+    port = int(os.environ.get("PORT", 5001)) # Changed default to 5001 to avoid conflict if run locally
+
+    # When running with `python app/main.py` for local dev:
+    # - debug=True will enable the reloader.
+    # - use_reloader=True (default when debug=True) can cause issues with schedulers
+    #   starting twice. The scheduler in EmailService has a lock to prevent the actual
+    #   loop from running twice, but it's cleaner to manage this.
+    #   However, since create_app now starts the thread, and Gunicorn is the target,
+    #   we might want to disable reloader here or be mindful of the scheduler's lock.
+    #   For Gunicorn, run.sh does not use this main() function.
     
     if Config.SCHEDULER_ENABLED:
-        threading.Thread(target=start_email_scheduler, daemon=True).start()
-        app.logger.info("Email scheduler started in background thread")
-    
-    # Use the correct port from Render
-    port = int(os.environ.get("PORT", 5000))
-    # Disable reloader to prevent multiple scheduler instances during development
-    app.run(debug=Config.DEBUG, host="0.0.0.0", port=port, use_reloader=False)
+        logger.info("Scheduler is configured to be enabled. It will be started by create_app().")
+    else:
+        logger.info("Scheduler is configured to be disabled.")
+
+    logger.info(f"Starting Flask development server on http://0.0.0.0:{port}")
+    # Note: Flask's reloader can cause the scheduler thread to be started twice
+    # if not careful. The lock in EmailService should prevent the actual job loop
+    # from running multiple times. For production, Gunicorn handles workers.
+    app.run(debug=Config.DEBUG, host="0.0.0.0", port=port, use_reloader=False) # Explicitly set use_reloader
 
 
 if __name__ == '__main__':
+    # This ensures that if someone runs `python app/main.py`, it starts the dev server.
+    # Gunicorn does not use this; it uses the `app:create_app()` factory.
     main()


### PR DESCRIPTION
The email scheduler was previously started in `app/main.py`, which is not executed by Gunicorn. This change moves the scheduler thread initialization into the `create_app` function in `app/__init__.py`.

This ensures that when Gunicorn calls `app:create_app()`, the scheduler's background thread is started. The scheduler service itself contains a lock to prevent multiple instances of the scheduling loop from running if multiple Gunicorn workers each attempt to start it.

Also includes minor cleanup of `app/main.py`.