### PR TITLE
Fix: Add initial delay to email scheduler for Render deployment

### DIFF
--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -42,6 +42,11 @@ class EmailService:
             logger.warning("If running multiple application instances (e.g., Gunicorn workers), ensure this scheduler is enabled in only ONE instance to avoid duplicate emails.")
 
         try:
+            # Add an initial delay before the first run
+            initial_delay_seconds = 30  # e.g., 30 seconds
+            logger.info(f"Scheduler starting. Initial delay of {initial_delay_seconds} seconds before first run.")
+            await asyncio.sleep(initial_delay_seconds)
+
             while True:
                 logger.debug("Scheduler loop iteration started.")
                 settings = {}


### PR DESCRIPTION
Adds an initial delay to the EmailService's scheduler loop before it processes reminders for the first time.

This change aims to improve deployment stability on platforms like Render by allowing the web application to fully initialize and become healthy before the scheduler starts its potentially resource-intensive tasks (like file I/O and network requests for email sending).

Additionally, acknowledges the existing /healthz endpoint for Render health checks and notes the current multi-worker scheduler behavior as an area for future improvement to prevent duplicate email sending.