### PR TITLE
Fix: Improve robustness of saving settings

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -315,12 +315,19 @@ def get_settings():
 @api_bp.route('/settings', methods=['POST'])
 def save_settings():
     """Save application settings."""
-    if not request.is_json:
-        logger.warning("Save settings request is not JSON.")
-        return jsonify({"error": "Request must be JSON"}), 400
+    logger.info(f"Attempting to save settings. Request headers: {request.headers}")
+    logger.info(f"Request Content-Type: {request.content_type}, is_json: {request.is_json}")
 
-    data = request.get_json()
-    logger.info(f"Received settings data for saving: {data}")
+    # Try to parse JSON irrespective of Content-Type header, handle failure gracefully
+    data = request.get_json(force=True, silent=True)
+
+    if data is None:
+        logger.warning(f"Failed to parse request body as JSON. Request data: {request.data[:200]}...") # Log first 200 chars of raw data
+        # The frontend reported "Invalid request format. Expected JSON."
+        # We'll return a similar error, but make it clear it's from our explicit check.
+        return jsonify({"error": "Invalid request format. Expected JSON data."}), 400
+
+    logger.info(f"Successfully parsed settings data: {data}")
 
     # Basic validation for expected keys and types
     email_notifications_enabled = data.get("email_notifications_enabled")


### PR DESCRIPTION
Modified the /api/settings endpoint to use request.get_json(force=True, silent=True) to ensure JSON parsing is attempted even if Content-Type headers are inconsistent.

Added specific error handling and logging for cases where JSON parsing fails, addressing an issue where push notification settings were not being saved correctly.