### PR TITLE
Fix: Add detailed logging for settings save request

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -315,14 +315,18 @@ def get_settings():
 @api_bp.route('/settings', methods=['POST'])
 def save_settings():
     """Save application settings."""
-    logger.info(f"Attempting to save settings. Request headers: {request.headers}")
-    logger.info(f"Request Content-Type: {request.content_type}, is_json: {request.is_json}")
+    # Added detailed logging for headers and raw body
+    logger.info(f"save_settings called. Request Method: {request.method}")
+    logger.info(f"Request Headers: {request.headers}")
+    logger.info(f"Request Content-Type: {request.content_type}")
+    logger.info(f"Request is_json: {request.is_json}")
+    logger.debug(f"Request raw data: {request.get_data(as_text=True)}") # Log raw data
 
     # Try to parse JSON irrespective of Content-Type header, handle failure gracefully
     data = request.get_json(force=True, silent=True)
 
     if data is None:
-        logger.warning(f"Failed to parse request body as JSON. Request data: {request.data[:200]}...") # Log first 200 chars of raw data
+        logger.warning(f"Failed to parse request body as JSON. Request data (first 200 chars): {request.data[:200]}...")
         # The frontend reported "Invalid request format. Expected JSON."
         # We'll return a similar error, but make it clear it's from our explicit check.
         return jsonify({"error": "Invalid request format. Expected JSON data."}), 400

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -119,13 +119,17 @@ document.addEventListener('DOMContentLoaded', function () {
             }
             console.log('Client-side validation passed.');
 
-            fetch('/api/settings', {
+            const fetchOptions = {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
                 },
                 body: JSON.stringify(settingsData),
-            })
+            };
+
+            console.log('Preparing to send settings. Options:', JSON.stringify(fetchOptions, null, 2)); // Log the options
+
+            fetch('/api/settings', fetchOptions)
             .then(response => response.json().then(data => ({ status: response.status, body: data })))
             .then(({ status, body }) => {
                 if (status === 200 && body.message) {


### PR DESCRIPTION
Adds comprehensive logging to both the frontend (settings.js) and backend (api.py) for the settings save functionality. This is intended to help diagnose an issue where 'Request format is not JSON' warnings appear despite the frontend seemingly sending correct JSON headers.

Frontend (app/static/js/settings.js):
- Logs the complete `fetchOptions` object (including headers and body) before the POST request to `/api/settings`.

Backend (app/routes/api.py):
- Logs incoming request method, headers, Content-Type, `is_json` status, and raw request body for the `/settings` POST route.
- The backend already used `request.get_json(force=True, silent=True)`, so its parsing logic remains tolerant.