### PR TITLE
Fix: Resolve AttributeError in barcode generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ google-api-python-client = "^2.172.0"
 mailjet-rest = "^1.4.0"
 gunicorn = "^23.0.0"
 pywebpush = "^2.0.3"
-python-barcode = "^0.14.0"
+python-barcode = "^0.15.1"
 Pillow = "^10.0.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Upgraded python-barcode to 0.15.1 to ensure compatibility with Pillow >= 10.0.0. This resolves the `AttributeError: 'FreeTypeFont' object has no attribute 'getsize'` that occurred during barcode image generation due to `python-barcode` 0.14.0 using a deprecated Pillow font method.