### PR TITLE
feat: Add logout link to navigation bar

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -235,6 +235,14 @@
                             Settings
                         </a>
                     </li>
+                    {% if current_user.is_authenticated %}
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ url_for('auth.logout') }}">
+                            <i class="fas fa-sign-out-alt"></i>
+                            Logout
+                        </a>
+                    </li>
+                    {% endif %}
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
- Added a logout link to the main navigation bar in base.html.
- The link is only visible when a user is authenticated.
- Clicking the link logs the user out and redirects to the login page.