### PR TITLE
feat: Secure Training Module routes and UI elements

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -242,6 +242,7 @@ def bulk_delete(data_type):
 
 @api_bp.route('/trainings', methods=['POST'])
 @login_required
+@permission_required('manage_training')
 def add_training_route():
     if not request.is_json:
         logger.warning("Add training request is not JSON")
@@ -261,6 +262,7 @@ def add_training_route():
 
 @api_bp.route('/trainings', methods=['GET'])
 @login_required
+@permission_required('view_training')
 def get_all_trainings_route():
     try:
         records = training_service.get_all_trainings()
@@ -271,6 +273,7 @@ def get_all_trainings_route():
 
 @api_bp.route('/trainings/<training_id>', methods=['GET'])
 @login_required
+@permission_required('view_training')
 def get_training_by_id_route(training_id):
     try:
         # Use training_id as string since the data stores IDs as strings
@@ -286,6 +289,7 @@ def get_training_by_id_route(training_id):
 
 @api_bp.route('/trainings/<training_id>', methods=['PUT'])
 @login_required
+@permission_required('manage_training')
 def update_training_route(training_id):
     if not request.is_json:
         logger.warning(f"Update training request for ID {training_id} is not JSON")
@@ -310,6 +314,7 @@ def update_training_route(training_id):
 
 @api_bp.route('/trainings/<training_id>', methods=['DELETE'])
 @login_required
+@permission_required('manage_training')
 def delete_training_route(training_id):
     try:
         # Use training_id as string since the data stores IDs as strings

--- a/app/routes/views.py
+++ b/app/routes/views.py
@@ -1015,7 +1015,7 @@ def send_test_email():
 # Training Management Page
 @views_bp.route('/training')
 @login_required
-@permission_required('View Training Records')
+@permission_required('view_training')
 def training_management_page():
     """Display the training management page."""
     logger.info("Training management page accessed")

--- a/app/templates/training/list.html
+++ b/app/templates/training/list.html
@@ -14,6 +14,7 @@
     
     <!-- Controls Row -->
     <div class="row mb-3">
+        {% if current_user.has_permission('manage_training') %}
         <div class="col-md-auto">
             <button type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#addTrainingModal">
                 <i class="fas fa-plus"></i> Add New Training
@@ -24,6 +25,7 @@
                 <i class="fas fa-trash"></i> Delete Selected (<span id="selectedCount">0</span>)
             </button>
         </div>
+        {% endif %}
         <div class="col-md-auto">
             <select id="filterEmployeeId" class="form-select d-inline-block" style="width: auto;" title="Filter by Employee ID">
                 <option value="">All Employees</option>
@@ -80,7 +82,7 @@
                     <th class="sortable" data-sort="next_due_date">
                         Next Due <i class="fas fa-sort"></i>
                     </th>
-                    <th>Actions</th>
+                    {% if current_user.has_permission('manage_training') %}<th>Actions</th>{% endif %}
                 </tr>
             </thead>
             <tbody>
@@ -125,6 +127,7 @@
                         </td>
                         <td>{{ training.last_trained_date if training.last_trained_date else 'N/A' }}</td>
                         <td>{{ training.next_due_date if training.next_due_date else 'N/A' }}</td>
+                        {% if current_user.has_permission('manage_training') %}
                         <td>
                             <button class="btn btn-sm btn-primary edit-training-btn"
                                     data-id="{{ training.id }}"
@@ -141,6 +144,7 @@
                                 <i class="fas fa-trash"></i> Delete
                             </button>
                         </td>
+                        {% endif %}
                     </tr>
                     {% endfor %}
                 {% else %}
@@ -153,6 +157,7 @@
     </div>
 </div>
 
+{% if current_user.has_permission('manage_training') %}
 <!-- Add Training Modal -->
 <div class="modal fade" id="addTrainingModal" tabindex="-1" aria-labelledby="addTrainingModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg">
@@ -306,6 +311,7 @@
         </div>
     </div>
 </div>
+{% endif %}
 
 {% endblock %}
 


### PR DESCRIPTION
Applies permission decorators to Training Module routes in views.py and api.py. Updates training list template to conditionally render management controls based on user permissions.

- `views.py`: Added `@permission_required('view_training')` to `training_management_page`.
- `api.py`:
    - Added `@permission_required('view_training')` to GET `/trainings` and `/trainings/<id>`.
    - Added `@permission_required('manage_training')` to POST, PUT, DELETE `/trainings` endpoints.
- `templates/training/list.html`: Wrapped "Add Record" button, bulk delete button, action column header, and action buttons (Edit/Delete) in `{% if current_user.has_permission('manage_training') %}` blocks. Also wrapped Add/Edit modals.